### PR TITLE
新規作成されるShowNoteにホストと内容のテンプレを設定する

### DIFF
--- a/apps/y2bot/app.rb
+++ b/apps/y2bot/app.rb
@@ -19,7 +19,50 @@ module App
       number = latest_number + 1
       date = Date.today
 
-      show_note = ShowNote.create!(name: "EP#{number}", number:, date:)
+      children = [
+        {
+          object: "block",
+          heading_2: {
+            rich_text: [{text: {content: "出囃子トーク"}}]
+          }
+        },
+        {
+          object: "block",
+          type: "bulleted_list_item",
+          bulleted_list_item: {
+            rich_text: [{type: "text", text: {content: "mk"}}]
+          }
+        },
+        {
+          object: "block",
+          type: "bulleted_list_item",
+          bulleted_list_item: {
+            rich_text: [{type: "text", text: {content: "ふっくん"}}]
+          }
+        },
+        {
+          object: "block",
+          type: "bulleted_list_item",
+          bulleted_list_item: {
+            rich_text: [{type: "text", text: {content: "とっしー"}}]
+          }
+        },
+        {
+          object: "block",
+          heading_2: {
+            rich_text: [{text: {content: "メインコンテンツ"}}]
+          }
+        },
+        {
+          object: "block",
+          type: "bulleted_list_item",
+          bulleted_list_item: {
+            rich_text: [{type: "text", text: {content: ""}}]
+          }
+        }
+      ]
+
+      show_note = ShowNote.create!(name: "EP#{number}", number:, date:, children:)
 
       show_note.to_h
     end

--- a/apps/y2bot/app.rb
+++ b/apps/y2bot/app.rb
@@ -19,6 +19,12 @@ module App
       number = latest_number + 1
       date = Date.today
 
+      user_ids = %w[
+        64609878-9e13-4eed-abde-f34470c6ece9
+        e3e92817-37b1-478e-ad41-1980c4cc1db5
+        c9c0887b-ace2-4152-acf6-ad46cb27914e
+      ]
+
       children = [
         {
           object: "block",
@@ -62,7 +68,7 @@ module App
         }
       ]
 
-      show_note = ShowNote.create!(name: "EP#{number}", number:, date:, children:)
+      show_note = ShowNote.create!(name: "EP#{number}", number:, date:, user_ids:, children:)
 
       show_note.to_h
     end

--- a/apps/y2bot/lib/notion_api/client.rb
+++ b/apps/y2bot/lib/notion_api/client.rb
@@ -21,7 +21,7 @@ module NotionApi
       client.send(method, path)
     end
 
-    def create_page_to_database(database_id:, name:, emoji_icon: nil, additional_properties: {})
+    def create_page_to_database(database_id:, name:, emoji_icon: nil, additional_properties: {}, children: nil)
       # @type var method: Symbol
       # @type var path: String
       method, path = post_page_endpoint.values_at(:method, :path)
@@ -39,7 +39,8 @@ module NotionApi
               }
             ]
           }
-        }.merge(additional_properties)
+        }.merge(additional_properties),
+        children:
       }.compact.to_json)
     end
 

--- a/apps/y2bot/lib/notion_api/client.rb
+++ b/apps/y2bot/lib/notion_api/client.rb
@@ -13,6 +13,14 @@ module NotionApi
     include Config
     include Endpoints
 
+    def get_page(page_id:)
+      # @type var method: Symbol
+      # @type var path: String
+      method, path = get_page_endpoint(page_id:).values_at(:method, :path)
+
+      client.send(method, path)
+    end
+
     def create_page_to_database(database_id:, name:, emoji_icon: nil, additional_properties: {})
       # @type var method: Symbol
       # @type var path: String

--- a/apps/y2bot/lib/notion_api/endpoints.rb
+++ b/apps/y2bot/lib/notion_api/endpoints.rb
@@ -4,6 +4,14 @@ module NotionApi
   module Endpoints
     private
 
+    # https://developers.notion.com/reference/retrieve-a-page
+    def get_page_endpoint(page_id:)
+      {
+        method: :get,
+        path: "/v1/pages/#{page_id}"
+      }
+    end
+
     # https://developers.notion.com/reference/post-page
     def post_page_endpoint
       {

--- a/apps/y2bot/models/show_note.rb
+++ b/apps/y2bot/models/show_note.rb
@@ -17,6 +17,21 @@ class ShowNote < BaseModel
     @date = date
   end
 
+  def self.find(notion_page_id)
+    client = NotionApi::Client.new
+
+    response = client.get_page(page_id: notion_page_id)
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    new(
+      name: json.dig(:properties, :Name, :title, 0, :plain_text),
+      number: json.dig(:properties, :Number, :number),
+      date: json.dig(:properties, :収録日時, :date, :start),
+      notion_page_id: json[:id]
+    )
+  end
+
   def self.create!(name:, number: nil, date: nil)
     client = NotionApi::Client.new
 

--- a/apps/y2bot/models/show_note.rb
+++ b/apps/y2bot/models/show_note.rb
@@ -40,7 +40,13 @@ class ShowNote < BaseModel
       "収録日時": {date: {start: date}}
     }
 
-    response = client.create_page_to_database(database_id: ENV["NOTION_SHOW_NOTES_DATABASE_ID"].to_s, name:, emoji_icon: "📝", additional_properties:, children:)
+    response = client.create_page_to_database(
+      database_id: ENV["NOTION_SHOW_NOTES_DATABASE_ID"].to_s,
+      name:,
+      emoji_icon: "📝",
+      additional_properties:,
+      children:
+    )
 
     json = JSON.parse(response.body, symbolize_names: true)
 

--- a/apps/y2bot/models/show_note.rb
+++ b/apps/y2bot/models/show_note.rb
@@ -32,7 +32,7 @@ class ShowNote < BaseModel
     )
   end
 
-  def self.create!(name:, number: nil, date: nil)
+  def self.create!(name:, number: nil, date: nil, children: nil)
     client = NotionApi::Client.new
 
     additional_properties = {
@@ -40,7 +40,7 @@ class ShowNote < BaseModel
       "収録日時": {date: {start: date}}
     }
 
-    response = client.create_page_to_database(database_id: ENV["NOTION_SHOW_NOTES_DATABASE_ID"].to_s, name:, emoji_icon: "📝", additional_properties:)
+    response = client.create_page_to_database(database_id: ENV["NOTION_SHOW_NOTES_DATABASE_ID"].to_s, name:, emoji_icon: "📝", additional_properties:, children:)
 
     json = JSON.parse(response.body, symbolize_names: true)
 

--- a/apps/y2bot/models/show_note.rb
+++ b/apps/y2bot/models/show_note.rb
@@ -32,13 +32,16 @@ class ShowNote < BaseModel
     )
   end
 
-  def self.create!(name:, number: nil, date: nil, children: nil)
+  def self.create!(name:, number: nil, date: nil, user_ids: [], children: nil)
     client = NotionApi::Client.new
+
+    people = user_ids.map { |id| {object: "user", id:} }
 
     additional_properties = {
       Number: {number:},
-      "収録日時": {date: {start: date}}
-    }
+      "収録日時": {date: {start: date}},
+      "ホスト": (people.length >= 1) ? {people:} : nil
+    }.compact
 
     response = client.create_page_to_database(
       database_id: ENV["NOTION_SHOW_NOTES_DATABASE_ID"].to_s,

--- a/apps/y2bot/sig/models/show_note.rbs
+++ b/apps/y2bot/sig/models/show_note.rbs
@@ -5,6 +5,8 @@ class ShowNote
   attr_accessor number: Integer?
   attr_accessor date: Date?
 
+  def self.find: (String notion_page_id) -> ShowNote
+
   def self.create!: (name: String, number: Integer?, date: Date?) -> ShowNote
 
   private

--- a/apps/y2bot/sig/notion_api/client.rbs
+++ b/apps/y2bot/sig/notion_api/client.rbs
@@ -5,6 +5,8 @@ module NotionApi
 
     @client: Faraday::Connection
 
+    def get_page: (page_id: String) -> Faraday::Response
+
     def create_page_to_database: (database_id: String, name: String, emoji_icon: String?, additional_properties: Hash[Symbol, untyped]) -> Faraday::Response
 
     private

--- a/apps/y2bot/sig/notion_api/client.rbs
+++ b/apps/y2bot/sig/notion_api/client.rbs
@@ -7,7 +7,7 @@ module NotionApi
 
     def get_page: (page_id: String) -> Faraday::Response
 
-    def create_page_to_database: (database_id: String, name: String, emoji_icon: String?, additional_properties: Hash[Symbol, untyped]) -> Faraday::Response
+    def create_page_to_database: (database_id: String, name: String, emoji_icon: String?, additional_properties: Hash[Symbol, untyped], children: Array[Hash[Symbol, untyped]]?) -> Faraday::Response
 
     private
 

--- a/apps/y2bot/sig/notion_api/endpoints.rbs
+++ b/apps/y2bot/sig/notion_api/endpoints.rbs
@@ -2,6 +2,8 @@ module NotionApi
   module Endpoints
     private
 
+    def get_page_endpoint: (page_id: String) -> Hash[Symbol, Symbol | String]
+
     def post_page_endpoint: -> Hash[Symbol, Symbol | String]
   end
 end

--- a/apps/y2bot/spec/fixtures/cassettes/NotionApi_Client/_create_page_to_database/with_children/creates_a_new_page_with_children.yml
+++ b/apps/y2bot/spec/fixtures/cassettes/NotionApi_Client/_create_page_to_database/with_children/creates_a_new_page_with_children.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.notion.com/v1/pages
+    body:
+      encoding: UTF-8
+      string: '{"parent":{"database_id":"18dc745e-9cf6-4a24-99e8-ecf9f8399e32"},"properties":{"Name":{"title":[{"text":{"content":"for
+        testing"}}]}},"children":[{"object":"block","heading_2":{"rich_text":[{"text":{"content":"見出しレベル2"}}]}},{"object":"block","type":"bulleted_list_item","bulleted_list_item":{"rich_text":[{"type":"text","text":{"content":"リスト1"}}]}},{"object":"block","type":"bulleted_list_item","bulleted_list_item":{"rich_text":[{"type":"text","text":{"content":"リスト2"}}]}}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Notion-Version:
+      - '2022-06-28'
+      User-Agent:
+      - Faraday v2.9.0
+      Authorization:
+      - Bearer <NOTION_API_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 25 Feb 2024 10:31:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJvYmplY3QiOiJwYWdlIiwiaWQiOiIzMzZiZmE5OC1iYmEyLTRlNzQtYTg1NS1hZmUzN2E4MDY2M2QiLCJjcmVhdGVkX3RpbWUiOiIyMDI0LTAyLTI1VDEwOjMxOjAwLjAwMFoiLCJsYXN0X2VkaXRlZF90aW1lIjoiMjAyNC0wMi0yNVQxMDozMTowMC4wMDBaIiwiY3JlYXRlZF9ieSI6eyJvYmplY3QiOiJ1c2VyIiwiaWQiOiI5OTFlZWM1MC05NmEzLTRhNTctYmQ3MS02ZTdiYTcxZDk3YjEifSwibGFzdF9lZGl0ZWRfYnkiOnsib2JqZWN0IjoidXNlciIsImlkIjoiOTkxZWVjNTAtOTZhMy00YTU3LWJkNzEtNmU3YmE3MWQ5N2IxIn0sImNvdmVyIjpudWxsLCJpY29uIjpudWxsLCJwYXJlbnQiOnsidHlwZSI6ImRhdGFiYXNlX2lkIiwiZGF0YWJhc2VfaWQiOiIxOGRjNzQ1ZS05Y2Y2LTRhMjQtOTllOC1lY2Y5ZjgzOTllMzIifSwiYXJjaGl2ZWQiOmZhbHNlLCJwcm9wZXJ0aWVzIjp7IuOCsuOCueODiCI6eyJpZCI6IkRtelgiLCJ0eXBlIjoicmljaF90ZXh0IiwicmljaF90ZXh0IjpbXX0sIk51bWJlciI6eyJpZCI6IkpzSSU1RSIsInR5cGUiOiJudW1iZXIiLCJudW1iZXIiOm51bGx9LCLlj47pjLLml6XmmYIiOnsiaWQiOiIlNUMlM0ZsaSIsInR5cGUiOiJkYXRlIiwiZGF0ZSI6bnVsbH0sIuODm+OCueODiCI6eyJpZCI6Im5KR3MiLCJ0eXBlIjoicGVvcGxlIiwicGVvcGxlIjpbXX0sIk5hbWUiOnsiaWQiOiJ0aXRsZSIsInR5cGUiOiJ0aXRsZSIsInRpdGxlIjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOnsiY29udGVudCI6ImZvciB0ZXN0aW5nIiwibGluayI6bnVsbH0sImFubm90YXRpb25zIjp7ImJvbGQiOmZhbHNlLCJpdGFsaWMiOmZhbHNlLCJzdHJpa2V0aHJvdWdoIjpmYWxzZSwidW5kZXJsaW5lIjpmYWxzZSwiY29kZSI6ZmFsc2UsImNvbG9yIjoiZGVmYXVsdCJ9LCJwbGFpbl90ZXh0IjoiZm9yIHRlc3RpbmciLCJocmVmIjpudWxsfV19fSwidXJsIjoiaHR0cHM6Ly93d3cubm90aW9uLnNvL2Zvci10ZXN0aW5nLTMzNmJmYTk4YmJhMjRlNzRhODU1YWZlMzdhODA2NjNkIiwicHVibGljX3VybCI6bnVsbCwicmVxdWVzdF9pZCI6Ijk0MTgzYzJiLTJlZTYtNGQ2My1iZmU4LWE3OWYyZTlhZmJmMCJ9
+  recorded_at: Sun, 25 Feb 2024 10:31:12 GMT
+recorded_with: VCR 6.2.0

--- a/apps/y2bot/spec/fixtures/cassettes/NotionApi_Client/_get_page/gets_a_page.yml
+++ b/apps/y2bot/spec/fixtures/cassettes/NotionApi_Client/_get_page/gets_a_page.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.notion.com/v1/pages/d722161b-7fe6-4ddb-99b0-8c452697fe01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Notion-Version:
+      - '2022-06-28'
+      User-Agent:
+      - Faraday v2.9.0
+      Authorization:
+      - Bearer <NOTION_API_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 24 Feb 2024 08:21:56 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJvYmplY3QiOiJwYWdlIiwiaWQiOiJkNzIyMTYxYi03ZmU2LTRkZGItOTliMC04YzQ1MjY5N2ZlMDEiLCJjcmVhdGVkX3RpbWUiOiIyMDIzLTA3LTE5VDAxOjE0OjAwLjAwMFoiLCJsYXN0X2VkaXRlZF90aW1lIjoiMjAyMy0xMi0xMFQwMTo0NzowMC4wMDBaIiwiY3JlYXRlZF9ieSI6eyJvYmplY3QiOiJ1c2VyIiwiaWQiOiI2NDYwOTg3OC05ZTEzLTRlZWQtYWJkZS1mMzQ0NzBjNmVjZTkifSwibGFzdF9lZGl0ZWRfYnkiOnsib2JqZWN0IjoidXNlciIsImlkIjoiNjQ2MDk4NzgtOWUxMy00ZWVkLWFiZGUtZjM0NDcwYzZlY2U5In0sImNvdmVyIjpudWxsLCJpY29uIjp7InR5cGUiOiJlbW9qaSIsImVtb2ppIjoi8J+RpSJ9LCJwYXJlbnQiOnsidHlwZSI6ImRhdGFiYXNlX2lkIiwiZGF0YWJhc2VfaWQiOiIxOGRjNzQ1ZS05Y2Y2LTRhMjQtOTllOC1lY2Y5ZjgzOTllMzIifSwiYXJjaGl2ZWQiOmZhbHNlLCJwcm9wZXJ0aWVzIjp7IuOCsuOCueODiCI6eyJpZCI6IkRtelgiLCJ0eXBlIjoicmljaF90ZXh0IiwicmljaF90ZXh0IjpbXX0sIk51bWJlciI6eyJpZCI6IkpzSSU1RSIsInR5cGUiOiJudW1iZXIiLCJudW1iZXIiOm51bGx9LCLlj47pjLLml6XmmYIiOnsiaWQiOiIlNUMlM0ZsaSIsInR5cGUiOiJkYXRlIiwiZGF0ZSI6bnVsbH0sIuODm+OCueODiCI6eyJpZCI6Im5KR3MiLCJ0eXBlIjoicGVvcGxlIiwicGVvcGxlIjpbeyJvYmplY3QiOiJ1c2VyIiwiaWQiOiI2NDYwOTg3OC05ZTEzLTRlZWQtYWJkZS1mMzQ0NzBjNmVjZTkifSx7Im9iamVjdCI6InVzZXIiLCJpZCI6ImUzZTkyODE3LTM3YjEtNDc4ZS1hZDQxLTE5ODBjNGNjMWRiNSJ9LHsib2JqZWN0IjoidXNlciIsImlkIjoiYzljMDg4N2ItYWNlMi00MTUyLWFjZjYtYWQ0NmNiMjc5MTRlIn1dfSwiTmFtZSI6eyJpZCI6InRpdGxlIiwidHlwZSI6InRpdGxlIiwidGl0bGUiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6eyJjb250ZW50Ijoi6YCa5bi45ZueIiwibGluayI6bnVsbH0sImFubm90YXRpb25zIjp7ImJvbGQiOmZhbHNlLCJpdGFsaWMiOmZhbHNlLCJzdHJpa2V0aHJvdWdoIjpmYWxzZSwidW5kZXJsaW5lIjpmYWxzZSwiY29kZSI6ZmFsc2UsImNvbG9yIjoiZGVmYXVsdCJ9LCJwbGFpbl90ZXh0Ijoi6YCa5bi45ZueIiwiaHJlZiI6bnVsbH1dfX0sInVybCI6Imh0dHBzOi8vd3d3Lm5vdGlvbi5zby9kNzIyMTYxYjdmZTY0ZGRiOTliMDhjNDUyNjk3ZmUwMSIsInB1YmxpY191cmwiOm51bGwsInJlcXVlc3RfaWQiOiI1NDUwNDMwMS0wMWVkLTQ4NGYtYjljZC04MDBiZTA0MzdkZmIifQ==
+  recorded_at: Sat, 24 Feb 2024 08:21:56 GMT
+recorded_with: VCR 6.2.0

--- a/apps/y2bot/spec/fixtures/cassettes/ShowNote/_create_/1_2_1.yml
+++ b/apps/y2bot/spec/fixtures/cassettes/ShowNote/_create_/1_2_1.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.notion.com/v1/pages
+    body:
+      encoding: UTF-8
+      string: "{\"parent\":{\"database_id\":\"18dc745e-9cf6-4a24-99e8-ecf9f8399e32\"},\"icon\":{\"emoji\":\"\U0001F4DD\"},\"properties\":{\"Name\":{\"title\":[{\"text\":{\"content\":\"for
+        testing\"}}]},\"Number\":{\"number\":123456},\"収録日時\":{\"date\":{\"start\":\"2024-02-23\"}}}}"
+    headers:
+      Content-Type:
+      - application/json
+      Notion-Version:
+      - '2022-06-28'
+      User-Agent:
+      - Faraday v2.9.0
+      Authorization:
+      - Bearer <NOTION_API_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 24 Feb 2024 08:36:59 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJvYmplY3QiOiJwYWdlIiwiaWQiOiI3ZjhiYjFlZi1kOWVlLTQ5N2YtYWZjNi0zOWU5OWU5NWJjN2MiLCJjcmVhdGVkX3RpbWUiOiIyMDI0LTAyLTI0VDA4OjM2OjAwLjAwMFoiLCJsYXN0X2VkaXRlZF90aW1lIjoiMjAyNC0wMi0yNFQwODozNjowMC4wMDBaIiwiY3JlYXRlZF9ieSI6eyJvYmplY3QiOiJ1c2VyIiwiaWQiOiI5OTFlZWM1MC05NmEzLTRhNTctYmQ3MS02ZTdiYTcxZDk3YjEifSwibGFzdF9lZGl0ZWRfYnkiOnsib2JqZWN0IjoidXNlciIsImlkIjoiOTkxZWVjNTAtOTZhMy00YTU3LWJkNzEtNmU3YmE3MWQ5N2IxIn0sImNvdmVyIjpudWxsLCJpY29uIjp7InR5cGUiOiJlbW9qaSIsImVtb2ppIjoi8J+TnSJ9LCJwYXJlbnQiOnsidHlwZSI6ImRhdGFiYXNlX2lkIiwiZGF0YWJhc2VfaWQiOiIxOGRjNzQ1ZS05Y2Y2LTRhMjQtOTllOC1lY2Y5ZjgzOTllMzIifSwiYXJjaGl2ZWQiOmZhbHNlLCJwcm9wZXJ0aWVzIjp7IuOCsuOCueODiCI6eyJpZCI6IkRtelgiLCJ0eXBlIjoicmljaF90ZXh0IiwicmljaF90ZXh0IjpbXX0sIk51bWJlciI6eyJpZCI6IkpzSSU1RSIsInR5cGUiOiJudW1iZXIiLCJudW1iZXIiOjEyMzQ1Nn0sIuWPjumMsuaXpeaZgiI6eyJpZCI6IiU1QyUzRmxpIiwidHlwZSI6ImRhdGUiLCJkYXRlIjp7InN0YXJ0IjoiMjAyNC0wMi0yMyIsImVuZCI6bnVsbCwidGltZV96b25lIjpudWxsfX0sIuODm+OCueODiCI6eyJpZCI6Im5KR3MiLCJ0eXBlIjoicGVvcGxlIiwicGVvcGxlIjpbXX0sIk5hbWUiOnsiaWQiOiJ0aXRsZSIsInR5cGUiOiJ0aXRsZSIsInRpdGxlIjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOnsiY29udGVudCI6ImZvciB0ZXN0aW5nIiwibGluayI6bnVsbH0sImFubm90YXRpb25zIjp7ImJvbGQiOmZhbHNlLCJpdGFsaWMiOmZhbHNlLCJzdHJpa2V0aHJvdWdoIjpmYWxzZSwidW5kZXJsaW5lIjpmYWxzZSwiY29kZSI6ZmFsc2UsImNvbG9yIjoiZGVmYXVsdCJ9LCJwbGFpbl90ZXh0IjoiZm9yIHRlc3RpbmciLCJocmVmIjpudWxsfV19fSwidXJsIjoiaHR0cHM6Ly93d3cubm90aW9uLnNvL2Zvci10ZXN0aW5nLTdmOGJiMWVmZDllZTQ5N2ZhZmM2MzllOTllOTViYzdjIiwicHVibGljX3VybCI6bnVsbCwicmVxdWVzdF9pZCI6ImQ0MmY1ZTI1LTgxMzYtNGU4Yi04MzdlLWQ4ZTdhZTFhOTMyZiJ9
+  recorded_at: Sat, 24 Feb 2024 08:36:59 GMT
+recorded_with: VCR 6.2.0

--- a/apps/y2bot/spec/fixtures/cassettes/ShowNote/_create_/with_user_ids/1_2_2_1.yml
+++ b/apps/y2bot/spec/fixtures/cassettes/ShowNote/_create_/with_user_ids/1_2_2_1.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.notion.com/v1/pages
+    body:
+      encoding: UTF-8
+      string: "{\"parent\":{\"database_id\":\"18dc745e-9cf6-4a24-99e8-ecf9f8399e32\"},\"icon\":{\"emoji\":\"\U0001F4DD\"},\"properties\":{\"Name\":{\"title\":[{\"text\":{\"content\":\"for
+        testing\"}}]},\"Number\":{\"number\":123456},\"収録日時\":{\"date\":{\"start\":\"2024-02-23\"}},\"ホスト\":{\"people\":[{\"object\":\"user\",\"id\":\"64609878-9e13-4eed-abde-f34470c6ece9\"},{\"object\":\"user\",\"id\":\"e3e92817-37b1-478e-ad41-1980c4cc1db5\"},{\"object\":\"user\",\"id\":\"c9c0887b-ace2-4152-acf6-ad46cb27914e\"}]}}}"
+    headers:
+      Content-Type:
+      - application/json
+      Notion-Version:
+      - '2022-06-28'
+      User-Agent:
+      - Faraday v2.9.0
+      Authorization:
+      - Bearer <NOTION_API_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 25 Feb 2024 11:21:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJvYmplY3QiOiJwYWdlIiwiaWQiOiI5OTRhYTZiNi1hOGYyLTRhOTktODdlZS1iMTBiOWUzN2ZlMWEiLCJjcmVhdGVkX3RpbWUiOiIyMDI0LTAyLTI1VDExOjIxOjAwLjAwMFoiLCJsYXN0X2VkaXRlZF90aW1lIjoiMjAyNC0wMi0yNVQxMToyMTowMC4wMDBaIiwiY3JlYXRlZF9ieSI6eyJvYmplY3QiOiJ1c2VyIiwiaWQiOiI5OTFlZWM1MC05NmEzLTRhNTctYmQ3MS02ZTdiYTcxZDk3YjEifSwibGFzdF9lZGl0ZWRfYnkiOnsib2JqZWN0IjoidXNlciIsImlkIjoiOTkxZWVjNTAtOTZhMy00YTU3LWJkNzEtNmU3YmE3MWQ5N2IxIn0sImNvdmVyIjpudWxsLCJpY29uIjp7InR5cGUiOiJlbW9qaSIsImVtb2ppIjoi8J+TnSJ9LCJwYXJlbnQiOnsidHlwZSI6ImRhdGFiYXNlX2lkIiwiZGF0YWJhc2VfaWQiOiIxOGRjNzQ1ZS05Y2Y2LTRhMjQtOTllOC1lY2Y5ZjgzOTllMzIifSwiYXJjaGl2ZWQiOmZhbHNlLCJwcm9wZXJ0aWVzIjp7IuOCsuOCueODiCI6eyJpZCI6IkRtelgiLCJ0eXBlIjoicmljaF90ZXh0IiwicmljaF90ZXh0IjpbXX0sIk51bWJlciI6eyJpZCI6IkpzSSU1RSIsInR5cGUiOiJudW1iZXIiLCJudW1iZXIiOjEyMzQ1Nn0sIuWPjumMsuaXpeaZgiI6eyJpZCI6IiU1QyUzRmxpIiwidHlwZSI6ImRhdGUiLCJkYXRlIjp7InN0YXJ0IjoiMjAyNC0wMi0yMyIsImVuZCI6bnVsbCwidGltZV96b25lIjpudWxsfX0sIuODm+OCueODiCI6eyJpZCI6Im5KR3MiLCJ0eXBlIjoicGVvcGxlIiwicGVvcGxlIjpbeyJvYmplY3QiOiJ1c2VyIiwiaWQiOiI2NDYwOTg3OC05ZTEzLTRlZWQtYWJkZS1mMzQ0NzBjNmVjZTkiLCJuYW1lIjoiVGFrdXlhIE11a29oaXJhIiwiYXZhdGFyX3VybCI6Imh0dHBzOi8vbGgzLmdvb2dsZXVzZXJjb250ZW50LmNvbS9hLS9BT2gxNEdoaC1HZ28zMzhfVm5ZODdvZEZUZkFYYmFBOGhiWDRWdjdDQU1nOTVBPXMxMDAiLCJ0eXBlIjoicGVyc29uIiwicGVyc29uIjp7ImVtYWlsIjoidGFrdXlhLm1rOTZAZ21haWwuY29tIn19LHsib2JqZWN0IjoidXNlciIsImlkIjoiZTNlOTI4MTctMzdiMS00NzhlLWFkNDEtMTk4MGM0Y2MxZGI1IiwibmFtZSI6IuOBteOBo+OBj+OCkyIsImF2YXRhcl91cmwiOm51bGwsInR5cGUiOiJwZXJzb24iLCJwZXJzb24iOnsiZW1haWwiOiJmdWt1cm91LmJiYi4yM0BnbWFpbC5jb20ifX0seyJvYmplY3QiOiJ1c2VyIiwiaWQiOiJjOWMwODg3Yi1hY2UyLTQxNTItYWNmNi1hZDQ2Y2IyNzkxNGUiLCJuYW1lIjoiVG9zaGlha2kgU2Vpbm8iLCJhdmF0YXJfdXJsIjoiaHR0cHM6Ly9saDMuZ29vZ2xldXNlcmNvbnRlbnQuY29tLy1Hc1hxNXBBV3dpcy9BQUFBQUFBQUFBSS9BQUFBQUFBQUhsVS9odnlXZE5ESWxPUS9waG90by5qcGciLCJ0eXBlIjoicGVyc29uIiwicGVyc29uIjp7ImVtYWlsIjoic3QxMjMxOEBnbWFpbC5jb20ifX1dfSwiTmFtZSI6eyJpZCI6InRpdGxlIiwidHlwZSI6InRpdGxlIiwidGl0bGUiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6eyJjb250ZW50IjoiZm9yIHRlc3RpbmciLCJsaW5rIjpudWxsfSwiYW5ub3RhdGlvbnMiOnsiYm9sZCI6ZmFsc2UsIml0YWxpYyI6ZmFsc2UsInN0cmlrZXRocm91Z2giOmZhbHNlLCJ1bmRlcmxpbmUiOmZhbHNlLCJjb2RlIjpmYWxzZSwiY29sb3IiOiJkZWZhdWx0In0sInBsYWluX3RleHQiOiJmb3IgdGVzdGluZyIsImhyZWYiOm51bGx9XX19LCJ1cmwiOiJodHRwczovL3d3dy5ub3Rpb24uc28vZm9yLXRlc3RpbmctOTk0YWE2YjZhOGYyNGE5OTg3ZWViMTBiOWUzN2ZlMWEiLCJwdWJsaWNfdXJsIjpudWxsLCJyZXF1ZXN0X2lkIjoiZmE4MmU0YzgtYjg0Yi00MDdjLWE0MjktMTg4NDFjNjFlODk5In0=
+  recorded_at: Sun, 25 Feb 2024 11:21:12 GMT
+recorded_with: VCR 6.2.0

--- a/apps/y2bot/spec/fixtures/cassettes/ShowNote/_find/1_1_1.yml
+++ b/apps/y2bot/spec/fixtures/cassettes/ShowNote/_find/1_1_1.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.notion.com/v1/pages/d722161b-7fe6-4ddb-99b0-8c452697fe01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Notion-Version:
+      - '2022-06-28'
+      User-Agent:
+      - Faraday v2.9.0
+      Authorization:
+      - Bearer <NOTION_API_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 24 Feb 2024 08:36:58 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJvYmplY3QiOiJwYWdlIiwiaWQiOiJkNzIyMTYxYi03ZmU2LTRkZGItOTliMC04YzQ1MjY5N2ZlMDEiLCJjcmVhdGVkX3RpbWUiOiIyMDIzLTA3LTE5VDAxOjE0OjAwLjAwMFoiLCJsYXN0X2VkaXRlZF90aW1lIjoiMjAyMy0xMi0xMFQwMTo0NzowMC4wMDBaIiwiY3JlYXRlZF9ieSI6eyJvYmplY3QiOiJ1c2VyIiwiaWQiOiI2NDYwOTg3OC05ZTEzLTRlZWQtYWJkZS1mMzQ0NzBjNmVjZTkifSwibGFzdF9lZGl0ZWRfYnkiOnsib2JqZWN0IjoidXNlciIsImlkIjoiNjQ2MDk4NzgtOWUxMy00ZWVkLWFiZGUtZjM0NDcwYzZlY2U5In0sImNvdmVyIjpudWxsLCJpY29uIjp7InR5cGUiOiJlbW9qaSIsImVtb2ppIjoi8J+RpSJ9LCJwYXJlbnQiOnsidHlwZSI6ImRhdGFiYXNlX2lkIiwiZGF0YWJhc2VfaWQiOiIxOGRjNzQ1ZS05Y2Y2LTRhMjQtOTllOC1lY2Y5ZjgzOTllMzIifSwiYXJjaGl2ZWQiOmZhbHNlLCJwcm9wZXJ0aWVzIjp7IuOCsuOCueODiCI6eyJpZCI6IkRtelgiLCJ0eXBlIjoicmljaF90ZXh0IiwicmljaF90ZXh0IjpbXX0sIk51bWJlciI6eyJpZCI6IkpzSSU1RSIsInR5cGUiOiJudW1iZXIiLCJudW1iZXIiOm51bGx9LCLlj47pjLLml6XmmYIiOnsiaWQiOiIlNUMlM0ZsaSIsInR5cGUiOiJkYXRlIiwiZGF0ZSI6bnVsbH0sIuODm+OCueODiCI6eyJpZCI6Im5KR3MiLCJ0eXBlIjoicGVvcGxlIiwicGVvcGxlIjpbeyJvYmplY3QiOiJ1c2VyIiwiaWQiOiI2NDYwOTg3OC05ZTEzLTRlZWQtYWJkZS1mMzQ0NzBjNmVjZTkifSx7Im9iamVjdCI6InVzZXIiLCJpZCI6ImUzZTkyODE3LTM3YjEtNDc4ZS1hZDQxLTE5ODBjNGNjMWRiNSJ9LHsib2JqZWN0IjoidXNlciIsImlkIjoiYzljMDg4N2ItYWNlMi00MTUyLWFjZjYtYWQ0NmNiMjc5MTRlIn1dfSwiTmFtZSI6eyJpZCI6InRpdGxlIiwidHlwZSI6InRpdGxlIiwidGl0bGUiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6eyJjb250ZW50Ijoi6YCa5bi45ZueIiwibGluayI6bnVsbH0sImFubm90YXRpb25zIjp7ImJvbGQiOmZhbHNlLCJpdGFsaWMiOmZhbHNlLCJzdHJpa2V0aHJvdWdoIjpmYWxzZSwidW5kZXJsaW5lIjpmYWxzZSwiY29kZSI6ZmFsc2UsImNvbG9yIjoiZGVmYXVsdCJ9LCJwbGFpbl90ZXh0Ijoi6YCa5bi45ZueIiwiaHJlZiI6bnVsbH1dfX0sInVybCI6Imh0dHBzOi8vd3d3Lm5vdGlvbi5zby9kNzIyMTYxYjdmZTY0ZGRiOTliMDhjNDUyNjk3ZmUwMSIsInB1YmxpY191cmwiOm51bGwsInJlcXVlc3RfaWQiOiJhZThiZmI3MC1iZmVmLTQ2OGMtYmM1NS00NjFmNmExODU5M2YifQ==
+  recorded_at: Sat, 24 Feb 2024 08:36:58 GMT
+recorded_with: VCR 6.2.0

--- a/apps/y2bot/spec/lib/notion_api/client_spec.rb
+++ b/apps/y2bot/spec/lib/notion_api/client_spec.rb
@@ -22,9 +22,10 @@ RSpec.describe NotionApi::Client, vcr: true do
   end
 
   describe "#create_page_to_database" do
-    subject {}
+    let(:params) { {database_id: ENV["NOTION_SHOW_NOTES_DATABASE_ID"], name: "for testing", children:} }
+    let(:children) { nil }
 
-    let(:response) { instance.create_page_to_database(database_id: ENV["NOTION_SHOW_NOTES_DATABASE_ID"], name: "for testing") }
+    let(:response) { instance.create_page_to_database(**params) }
     let(:json) { JSON.parse(response.body, symbolize_names: true) }
 
     it "creates a new page" do
@@ -33,6 +34,45 @@ RSpec.describe NotionApi::Client, vcr: true do
       expect(json[:object]).to eq "page"
       expect(json[:parent]).to eq({type: "database_id", database_id: ENV["NOTION_SHOW_NOTES_DATABASE_ID"]})
       expect(json[:properties][:Name][:title][0][:text][:content]).to eq "for testing"
+    end
+
+    context "with children" do
+      let(:children) do
+        [
+          {
+            object: "block",
+            heading_2: {
+              rich_text: [{text: {content: "見出しレベル2"}}]
+            }
+          },
+          {
+            object: "block",
+            type: "bulleted_list_item",
+            bulleted_list_item: {
+              rich_text: [
+                {type: "text", text: {content: "リスト1"}}
+              ]
+            }
+          },
+          {
+            object: "block",
+            type: "bulleted_list_item",
+            bulleted_list_item: {
+              rich_text: [
+                {type: "text", text: {content: "リスト2"}}
+              ]
+            }
+          }
+        ]
+      end
+
+      it "creates a new page with children" do
+        expect(response.success?).to eq true
+
+        expect(json[:object]).to eq "page"
+        expect(json[:parent]).to eq({type: "database_id", database_id: ENV["NOTION_SHOW_NOTES_DATABASE_ID"]})
+        expect(json[:properties][:Name][:title][0][:text][:content]).to eq "for testing"
+      end
     end
   end
 end

--- a/apps/y2bot/spec/lib/notion_api/client_spec.rb
+++ b/apps/y2bot/spec/lib/notion_api/client_spec.rb
@@ -7,6 +7,20 @@ require_relative "../../../lib/notion_api/client"
 RSpec.describe NotionApi::Client, vcr: true do
   let(:instance) { described_class.new }
 
+  describe "#get_page" do
+    let(:page_id) { "d722161b-7fe6-4ddb-99b0-8c452697fe01" }
+
+    let(:response) { instance.get_page(page_id:) }
+    let(:json) { JSON.parse(response.body, symbolize_names: true) }
+
+    it "gets a page" do
+      expect(response.success?).to eq true
+
+      expect(json[:object]).to eq "page"
+      expect(json[:id]).to eq page_id
+    end
+  end
+
   describe "#create_page_to_database" do
     subject {}
 

--- a/apps/y2bot/spec/models/show_note_spec.rb
+++ b/apps/y2bot/spec/models/show_note_spec.rb
@@ -18,8 +18,23 @@ RSpec.describe ShowNote do
     let(:number) { 123456 }
     let(:date) { Date.new(2024, 2, 23) }
 
-    subject { described_class.create!(name:, number:, date:) }
+    let(:params) { {name:, number:, date:} }
+
+    subject { described_class.create!(**params) }
 
     it { is_expected.to be_a(described_class) }
+
+    context "with user_ids" do
+      let(:user_ids) {
+        %w[
+          64609878-9e13-4eed-abde-f34470c6ece9
+          e3e92817-37b1-478e-ad41-1980c4cc1db5
+          c9c0887b-ace2-4152-acf6-ad46cb27914e
+        ]
+      }
+      let(:params) { {name:, number:, date:, user_ids:} }
+
+      it { is_expected.to be_a(described_class) }
+    end
   end
 end

--- a/apps/y2bot/spec/models/show_note_spec.rb
+++ b/apps/y2bot/spec/models/show_note_spec.rb
@@ -5,6 +5,14 @@ require_relative "../spec_helper"
 require_relative "../../models/show_note"
 
 RSpec.describe ShowNote do
+  describe ".find", vcr: true do
+    let(:notion_page_id) { "d722161b-7fe6-4ddb-99b0-8c452697fe01" }
+
+    subject { described_class.find(notion_page_id) }
+
+    it { is_expected.to be_a(described_class) }
+  end
+
   describe ".create!", vcr: true do
     let(:name) { "for testing" }
     let(:number) { 123456 }


### PR DESCRIPTION
## 概要

新規作成するShowNoteに、ホストと内容を追記する。


## TODO

- [x] `NotionApi::Client#get_page` の実装
- [x] テンプレのホスト・内容をコピーし新規作成するページに追記する

