### PR TITLE
Slack投稿にてリンクのプレビューがされるようにする

### DIFF
--- a/apps/y2bot/lib/slack/client.rb
+++ b/apps/y2bot/lib/slack/client.rb
@@ -16,7 +16,8 @@ module Slack
       client.post(
         webhook_url,
         {
-          text: content
+          text: content,
+          unfurl_links: true
         }.to_json,
         "Content-Type" => "application/json"
       )


### PR DESCRIPTION
## 概要

SlackのIncomming WebhookでURLが展開されない問題を解決する - funetwork
https://funet.work/blog/146
