### PR TITLE
ShowNote作成Botの動作を水曜朝9時にする

### DIFF
--- a/lib/y2bot/buildExecutionRuleForCreateNewShowNoteStateMachine.ts
+++ b/lib/y2bot/buildExecutionRuleForCreateNewShowNoteStateMachine.ts
@@ -13,7 +13,7 @@ export const buildExecutionRuleForCreateNewShowNoteStateMachine = (
   const { capitalize } = useCapitalize();
 
   return new events.Rule(stack, `ScheduleRuleForCreateNewShowNoteStateMachine${capitalize(props.stage)}`, {
-    schedule: events.Schedule.expression('cron(0 0 ? * FRI *)'), // 日本時間 金曜 朝9時
+    schedule: events.Schedule.expression('cron(0 0 ? * WED *)'), // 日本時間 水曜 朝9時
     targets: [new targets.SfnStateMachine(stateMachine)],
   });
 };


### PR DESCRIPTION
## 概要

yuru28の収録が毎週水曜になったので、ShowNote作成Botの動作を毎週水曜にする。


## TODO

- [ ] master merge後、ローカル環境で `cdk deploy -c stage=production` を実行する
